### PR TITLE
[amazonechocontrol]

### DIFF
--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -106,8 +106,8 @@ You will find the required serial number in settings of the device in the alexa 
 | Configuration name              | Default | Description                                                                           |
 |---------------------------------|---------|---------------------------------------------------------------------------------------|
 | discoverSmartHome               | 0       | 0...No discover, 1...Discover direct connected, 2...Discover direct and skill devices |
-| pollingIntervalSmartHome        | 10      | Defines the time in minutes for openHAB to pull the
-					state of the connected devices. The minimum is 10 minutes.                              |
+| pollingIntervalSmartHomeAlexa   | 30      | Defines the time in seconds for openHAB to pull the state of the Alexa connected devices. The minimum is 10 seconds. | 
+| pollingIntervalSmartSkills      | 120     | Defines the time in seconds for openHAB to pull the state of the over a skill connected devices. The minimum is 60 seconds. |
 | discoverOpenHabSmartHomeDevices | false   | Defines, if smart home devices of the openHAB skill should be discovered. This option is for development and testing purpose only. ||
 
 #### echo, echospot, echoshow, wha Things
@@ -320,7 +320,7 @@ It will be configured at runtime by using the save channel to store the current 
 #### flashbriefings.things
 
 ```
-Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2 pollingIntervalSmartHome=20]
+Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2]
 {
     Thing flashbriefingprofile flashbriefing1 "Flash Briefing Technical" @ "Flash Briefings" 
     Thing flashbriefingprofile flashbriefing2 "Flash Briefing Life Style" @ "Flash Briefings"
@@ -401,7 +401,7 @@ The only possibility to find out the id is by using the discover function in the
 #### smarthome.things
 
 ```
-Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2, pollingIntervalSmartHome=20]
+Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2, pollingIntervalSmartHomeAlexa=30, pollingIntervalSmartSkills=120]
 {
     Thing smartHomeDevice      smartHomeDevice1 "Smart Home Device 1" @ "Living Room" [id="ID"]
     Thing smartHomeDevice      smartHomeDevice2 "Smart Home Device 2" @ "Living Room" [id="ID"]

--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -167,7 +167,7 @@ You will find the serial number in the alexa app or on the webpage YOUR_OPENHAB/
 #### echo.things
 
 ```
-Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2 pollingIntervalSmartHome=20]
+Bridge amazonechocontrol:account:account1 "Amazon Account" @ "Accounts" [discoverSmartHome=2, pollingIntervalSmartHomeAlexa=30, pollingIntervalSmartSkills=120]
 {
     Thing echo                 echo1          "Alexa" @ "Living Room" [serialNumber="SERIAL_NUMBER"]
     Thing echoshow             echoshow1      "Alexa" @ "Kitchen" [serialNumber="SERIAL_NUMBER"]

--- a/bundles/org.openhab.binding.amazonechocontrol/README.md
+++ b/bundles/org.openhab.binding.amazonechocontrol/README.md
@@ -55,14 +55,14 @@ Some ideas what you can do in your home by using rules and other openHAB control
 - Implement own handling for voice commands in a rule
 - Change the equalizer settings depending on the bluetooth connection
 - Turn on a light on your alexa alarm time
-- Activate or deactive the Alexa Guard with presence detection
+- Activate or deactivate the Alexa Guard with presence detection
 
 With the possibility to control your lights you could do:
 
 - a scene-based configuration of your rooms
 - connect single bulbs to functions of openhab
 - simulate your presence at home
-- automaticly turn on your lights at the evening
+- automatically turn on your lights at the evening
 - integrate your smart bulbs with rules 
 
 ## Binding Configuration

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/JsonSmartHomeDevices.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/JsonSmartHomeDevices.java
@@ -27,6 +27,8 @@ public class JsonSmartHomeDevices {
 
     public static class SmartHomeDevice implements SmartHomeBaseDevice {
 
+        public @Nullable Integer UpdateIntervalInSeconds;
+
         @Override
         public @Nullable String findId() {
             return applianceId;

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceHandler.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceHandler.java
@@ -66,6 +66,7 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
     private @Nullable SmartHomeBaseDevice smartHomeBaseDevice;
     private Gson gson;
     private Map<String, HandlerBase> handlers = new HashMap<>();
+    private Map<String, JsonArray> lastStates = new HashMap<>();
 
     @Nullable
     AccountHandler accountHandler;
@@ -197,10 +198,18 @@ public class SmartHomeDeviceHandler extends BaseThingHandler {
         SmartHomeDevice firstDevice = null;
         for (SmartHomeDevice shd : GetSupportedSmartHomeDevices(smartHomeBaseDevice, allDevices)) {
             JsonArray states = applianceIdToCapabilityStates.get(shd.applianceId);
-            if (states == null) {
-                continue;
+            if (states != null) {
+                stateFound = true;
+                if (smartHomeBaseDevice.isGroup()) {
+                    // for groups, store the last state of all devices
+                    lastStates.put(shd.applianceId, states);
+                }
+            } else {
+                states = lastStates.get(shd.applianceId);
+                if (states == null) {
+                    continue;
+                }
             }
-            stateFound = true;
             if (firstDevice == null) {
                 firstDevice = shd;
             }

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/java/org/openhab/binding/amazonechocontrol/internal/smarthome/SmartHomeDeviceStateGroupUpdateCalculator.java
@@ -1,0 +1,123 @@
+/**
+ * Copyright (c) 2010-2019 Contributors to the openHAB project
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Eclipse Public License 2.0 which is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ */
+package org.openhab.binding.amazonechocontrol.internal.smarthome;
+
+import java.util.Date;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.commons.lang.StringUtils;
+import org.eclipse.jdt.annotation.NonNullByDefault;
+import org.openhab.binding.amazonechocontrol.internal.smarthome.JsonSmartHomeCapabilities.SmartHomeCapability;
+import org.openhab.binding.amazonechocontrol.internal.smarthome.JsonSmartHomeDevices.DriverIdentity;
+import org.openhab.binding.amazonechocontrol.internal.smarthome.JsonSmartHomeDevices.SmartHomeDevice;
+
+/**
+ * Handles the update interval calculation
+ *
+ * @author Michael Geramb
+ */
+@NonNullByDefault
+public class SmartHomeDeviceStateGroupUpdateCalculator {
+    static final boolean isDebug = java.lang.management.ManagementFactory.getRuntimeMXBean().getInputArguments()
+            .toString().indexOf("-agentlib:jdwp") > 0;
+
+    static final Integer updateIntervalPrivateSkillsInSeconds = isDebug ? 10 : 600;
+    static final Integer updateIntervalAcousticEventsInSeconds = 10;
+    Integer updateIntervalAmazonInSeconds;
+    Integer updateIntervalSkillsInSeconds;
+
+    class UpdateGroup {
+        int intervalInSeconds;
+        Date lastUpdated;
+    }
+
+    Map<Integer, UpdateGroup> updateGroups = new HashMap<>();
+
+    public SmartHomeDeviceStateGroupUpdateCalculator(int updateIntervalAmazonInSeconds,
+            int updateIntervalSkillsInSeconds) {
+        this.updateIntervalAmazonInSeconds = updateIntervalAmazonInSeconds;
+        this.updateIntervalSkillsInSeconds = updateIntervalSkillsInSeconds;
+    }
+
+    Integer GetUpdateIntervalInSeconds(SmartHomeDevice shd) {
+        Integer updateIntervalInSeconds = shd.UpdateIntervalInSeconds;
+        if (updateIntervalInSeconds != null) {
+            return updateIntervalInSeconds;
+        }
+        SmartHomeCapability[] capabilities = shd.capabilities;
+        if (capabilities != null) {
+            for (SmartHomeCapability capability : capabilities) {
+                if (capability != null && HandlerAcousticEventSensor.INTERFACE.equals(capability.interfaceName)) {
+                    updateIntervalInSeconds = updateIntervalAcousticEventsInSeconds;
+                    break;
+                }
+            }
+        }
+        if (updateIntervalInSeconds == null) {
+            if ("openHAB".equalsIgnoreCase(shd.manufacturerName)
+                    || StringUtils.startsWithIgnoreCase(shd.manufacturerName, "ioBroker")) {
+                // OpenHAB or ioBroker skill
+                updateIntervalInSeconds = updateIntervalPrivateSkillsInSeconds;
+
+            } else {
+                boolean isSkillDevice = false;
+                DriverIdentity driverIdentity = shd.driverIdentity;
+                isSkillDevice = driverIdentity != null && "SKILL".equals(driverIdentity.namespace);
+                if (isSkillDevice) {
+                    updateIntervalInSeconds = updateIntervalSkillsInSeconds;
+                } else {
+                    updateIntervalInSeconds = updateIntervalAmazonInSeconds;
+                }
+            }
+        }
+        shd.UpdateIntervalInSeconds = updateIntervalInSeconds;
+        return updateIntervalInSeconds;
+
+    }
+
+    public void RemoveDevicesWithNoUpdate(List<SmartHomeDevice> devices) {
+        Date updateTimeStamp = new Date();
+        // check if new group is needed
+        boolean syncAllGroups = false;
+        for (SmartHomeDevice device : devices) {
+            int updateIntervalInSeconds = GetUpdateIntervalInSeconds(device);
+            if (!updateGroups.containsKey(updateIntervalInSeconds)) {
+                UpdateGroup newGroup = new UpdateGroup();
+                newGroup.intervalInSeconds = updateIntervalInSeconds;
+                newGroup.lastUpdated = new Date(0);
+                updateGroups.put(updateIntervalInSeconds, newGroup);
+                syncAllGroups = true;
+            }
+        }
+        // check which groups needs an update
+        Set<Integer> groupsToUpdate = new HashSet<Integer>();
+        for (UpdateGroup group : updateGroups.values()) {
+            long millisecondsSinceLastUpdate = updateTimeStamp.getTime() - group.lastUpdated.getTime();
+            if (syncAllGroups || millisecondsSinceLastUpdate >= group.intervalInSeconds * 1000) {
+                group.lastUpdated = updateTimeStamp;
+                groupsToUpdate.add(group.intervalInSeconds);
+            }
+        }
+        // remove unused devices
+        for (int i = devices.size() - 1; i >= 0; i--) {
+            if (!groupsToUpdate.contains(GetUpdateIntervalInSeconds(devices.get(i)))) {
+                devices.remove(i);
+            }
+        }
+
+    }
+}

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/ESH-INF/i18n/amazonechocontrol_de.properties
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/ESH-INF/i18n/amazonechocontrol_de.properties
@@ -10,7 +10,8 @@ thing-type.amazonechocontrol.account.config-description.discoverSmartHome.descri
 thing-type.amazonechocontrol.account.config-description.discoverSmartHome.option.0 = Nicht finden
 thing-type.amazonechocontrol.account.config-description.discoverSmartHome.option.1 = Direkt verbundene
 thing-type.amazonechocontrol.account.config-description.discoverSmartHome.option.2 = Direkt und über Skill verbundene
-thing-type.amazonechocontrol.account.config-description.pollingIntervalSmartHome.description = Definiert das Intervall in Minuten, wie häufig OpenHAB den Status der Geräte abfragt.
+thing-type.amazonechocontrol.account.config-description.pollingIntervalSmartHomeAlexa.description = Definiert das Intervall in Sekunden, wie häufig OpenHAB den Status der mit Alexa verbundenen Geräte abfragt.
+thing-type.amazonechocontrol.account.config-description.pollingIntervalSmartSkills.description = Definiert das Intervall in Sekunden, wie häufig OpenHAB den Status der über Skill Geräte abfragt.
 thing-type.amazonechocontrol.account.config-description.discoverOpenHabSmartHomeDevices.description = Definiert ob auch Geräte die über den openHAB Skill verbunden sind, gefunden werden sollen. Diese Option ist nur für Entwicklungs- und Testzwecke.
 
 thing-type.amazonechocontrol.echo.label = Amazon Echo

--- a/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/ESH-INF/thing/thing-types.xml
+++ b/bundles/org.openhab.binding.amazonechocontrol/src/main/resources/ESH-INF/thing/thing-types.xml
@@ -17,12 +17,20 @@
 					<option value="2">Direct and over Alexa skill</option>
 				</options>
 			</parameter>
-			<parameter name="pollingIntervalSmartHome" type="decimal"
+			<parameter name="pollingIntervalSmartHomeAlexa" type="decimal"
 				min="10">
-				<default>10</default>
+				<default>30</default>
 				<description>
-					Defines the time in minutes for openHAB to pull the
-					state of the connected devices. The minimum is 10 minutes.
+					Defines the time in seconds for openHAB to pull the
+					state of the Alexa connected devices. The minimum is 10 seconds.
+				</description>
+			</parameter>
+			<parameter name="pollingIntervalSmartSkills" type="decimal"
+				min="60">
+				<default>120</default>
+				<description>
+					Defines the time in seconds for openHAB to pull the
+					state of the over a skill connected devices. The minimum is 60 seconds.
 				</description>
 			</parameter>
 			<parameter name="discoverOpenHabSmartHomeDevices"


### PR DESCRIPTION
I have added the update groups for smarthome.
There are now two config values in the account:

- pollingIntervalSmartHomeAlexa  Default: 30   Defines the time in seconds for openHAB to pull the state of the Alexa connected devices. The minimum is 10 seconds. 
- pollingIntervalSmartSkills  Default: 120 Defines the time in seconds for openHAB to pull the state of the over a skill connected devices. The minimum is 60 seconds. 

The Alexa Guard will be polled with a fixed interval of 10 seconds.
The Skill Devices of openHAB and ioBroker with an interval of 600 seconds.